### PR TITLE
Sha256 fix

### DIFF
--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -23,6 +23,8 @@ eosio-macro = { version = "0.2", path = "../macro", default-features = false }
 chaintester = { version = "0.2", path = "../chaintester", default-features = false, optional = true }
 eosio-scale-info = { version="2.1.3",  default-features = false, features = ["derive"], optional = true }
 
+rustversion = "1.0"
+
 [features]
 default = ["std"]
 std = [

--- a/crates/chain/src/db.rs
+++ b/crates/chain/src/db.rs
@@ -843,7 +843,7 @@ impl IdxTable for Idx256Table {
 
     fn store(&self, key: u64, secondary: SecondaryValue, payer: Name) -> SecondaryIterator {
         if let SecondaryValue::Idx256(value) = secondary {
-            let ret = db_idx256_store(self.scope, self.table, payer.value(), key, value.data.as_ptr() as *mut Uint128, 2);
+            let ret = db_idx256_store(self.scope, self.table, payer.value(), key, value.to_big_endian().data.as_ptr() as *mut Uint128, 2);
             return SecondaryIterator{ i: ret, primary: key, db_index: self.db_index };
         }
         check(false, "Idx256Table::store: bad secondary type");
@@ -852,7 +852,7 @@ impl IdxTable for Idx256Table {
 
     fn update(&self, iterator: &SecondaryIterator, secondary: SecondaryValue, payer: Name) {
         if let SecondaryValue::Idx256(value) = secondary {
-            db_idx256_update(iterator.i, payer.value(), value.data.as_ptr() as *mut Uint128, 2);
+            db_idx256_update(iterator.i, payer.value(), value.to_big_endian().data.as_ptr() as *mut Uint128, 2);
         } else {
             check(false, "Idx256Table::update: bad secondary type");
         }
@@ -878,13 +878,13 @@ impl IdxTable for Idx256Table {
         //initialize Uint128
         let mut secondary = Uint256{data: [0; 2]};
         let ret = db_idx256_find_primary(self.code, self.scope, self.table, secondary.data.as_mut_ptr() as *mut Uint128, 2, primary);
-        return (SecondaryIterator{ i: ret, primary: primary, db_index: self.db_index }, SecondaryValue::Idx256(secondary));
+        return (SecondaryIterator{ i: ret, primary: primary, db_index: self.db_index }, SecondaryValue::Idx256(secondary.to_big_endian()));
     }
 
     fn find(&self, secondary: SecondaryValue) -> SecondaryIterator {
         if let SecondaryValue::Idx256(mut value) = secondary {
             let mut primary = 0;
-            let ret = db_idx256_find_secondary(self.code, self.scope, self.table, value.data.as_mut_ptr() as *mut Uint128, 2, &mut primary);
+            let ret = db_idx256_find_secondary(self.code, self.scope, self.table, value.to_big_endian().data.as_mut_ptr() as *mut Uint128, 2, &mut primary);
             return SecondaryIterator{ i: ret, primary: primary, db_index: self.db_index };
         }
         check(false, "Idx256Table::find_secondary: bad secondary type");
@@ -894,7 +894,7 @@ impl IdxTable for Idx256Table {
     fn lower_bound(&self, secondary: SecondaryValue) -> (SecondaryIterator, SecondaryValue) {
         if let SecondaryValue::Idx256(mut value) = secondary {
             let mut primary = 0;
-            let ret = db_idx256_lowerbound(self.code, self.scope, self.table, value.data.as_mut_ptr() as *mut u8 as *mut Uint128, 2, &mut primary);
+            let ret = db_idx256_lowerbound(self.code, self.scope, self.table, value.to_big_endian().data.as_mut_ptr() as *mut u8 as *mut Uint128, 2, &mut primary);
             if ret >= 0 {
                 return (SecondaryIterator{ i: ret, primary: primary, db_index: self.db_index }, SecondaryValue::Idx256(value));
             } else {
@@ -909,7 +909,7 @@ impl IdxTable for Idx256Table {
         match secondary {
             SecondaryValue::Idx256(mut value) => {
                 let mut primary = 0;
-                let ret = db_idx256_upperbound(self.code, self.scope, self.table, value.data.as_mut_ptr() as *mut u8 as *mut Uint128, 2, &mut primary);
+                let ret = db_idx256_upperbound(self.code, self.scope, self.table, value.to_big_endian().data.as_mut_ptr() as *mut u8 as *mut Uint128, 2, &mut primary);
                 if ret >= 0 {
                     return (SecondaryIterator{ i: ret, primary: primary, db_index: self.db_index }, SecondaryValue::Idx256(value));
                 } else {

--- a/crates/chain/src/structs.rs
+++ b/crates/chain/src/structs.rs
@@ -522,6 +522,15 @@ impl Uint256 {
     pub fn swap(&self) -> Self {
         Self { data: [self.data[1], self.data[0]] }
     }
+
+    pub fn to_big_endian(&self) -> Self {
+        Self {
+            data: [
+                u128::from_be(self.data[1]),
+                u128::from_be(self.data[0]),
+            ],
+        }
+    }
 }
 
 impl Packer for Uint256 {

--- a/crates/chain/src/structs.rs
+++ b/crates/chain/src/structs.rs
@@ -515,19 +515,14 @@ pub struct Uint256 {
 impl Uint256 {
     ///
     pub fn new(lo: u128, hi: u128) -> Self {
-        Self { data: [hi, lo] }
-    }
-
-    ///
-    pub fn swap(&self) -> Self {
-        Self { data: [self.data[1], self.data[0]] }
+        Self { data: [lo, hi] }
     }
 
     pub fn to_big_endian(&self) -> Self {
         Self {
             data: [
-                u128::from_be(self.data[1]),
                 u128::from_be(self.data[0]),
+                u128::from_be(self.data[1]),
             ],
         }
     }
@@ -541,16 +536,16 @@ impl Packer for Uint256 {
 
     ///
     fn pack(&self, enc: &mut Encoder) -> usize {
-        self.data[1].pack(enc);
         self.data[0].pack(enc);
+        self.data[1].pack(enc);
         self.size()
     }
 
     ///
     fn unpack(&mut self, data: &[u8]) -> usize {
         let mut dec = Decoder::new(data);
-        dec.unpack(&mut self.data[1]);
         dec.unpack(&mut self.data[0]);
+        dec.unpack(&mut self.data[1]);
         return dec.get_pos();
     }
 }
@@ -560,7 +555,7 @@ impl Printable for Uint256 {
         if self.data[0] == 0 {
             printui128(self.data[1]);
         } else {
-            crate::vmapi::print::printhex(self.swap().data.as_ptr() as *mut u8, 32);
+            crate::vmapi::print::printhex(self.data.as_ptr() as *mut u8, 32);
         }
     }
 }


### PR DESCRIPTION
# Issue

While developing snarktor contracts and aggregator service it was found that in order to find the table an endianess transformation was necessary, as seen here:

- https://github.com/telosnetwork/antelope-rs/blob/d701cd9ca2e87e8e0fd99746f9c672cb3536e5ec/crates/antelope/src/api/v1/structs.rs#L488
- https://github.com/telosnetwork/antelope-rs/blob/d701cd9ca2e87e8e0fd99746f9c672cb3536e5ec/crates/antelope/src/chain/checksum.rs#L139

This test was a clear example of the issue:

- https://github.com/telosnetwork/snarktor-aggregator/blob/f4de8e86932953b8e008320b34a52f7bcc7d33c0/submitter/src/main.rs#L124

# Reproducing

Created two contracts that perform exactly same tasks and define same structs one in rust and one in C:

- `cindextest`: https://gist.github.com/guilledk/40a79e87803a62358a74e9743d978ed8
- `rindextest`: https://gist.github.com/guilledk/139d2021c8b6cbd76d752bf656dc3b02

Then created test that auto deploys contracts and calls the actions in three batches:

1. Emplace a pre-defined hash on both tables using `store` actions
2. Call `rload` function on both contracts to read and compare stored hash
3. Call `cload` function on both contracts to read and compare stored hash

Here is test python version: https://gist.github.com/guilledk/4b561aacaec627c5504754d3bc55f968
Here is test rust version: https://gist.github.com/guilledk/eb0bf73fa2b4788208d8d12f3cde6d62

When run without this branch, the test will succed until step 3, rust contract will fail to find the row in the C contract. Another interesting result is the output of the `dump` function on the rust contract:

`rindextest::dump`:

```rust
        #[chain(action = "dump")]
        pub fn dump(&self) {
            // print table contents using primary index
            let cdb = MyData::new_table(Name::from_str("cindextest"));
            let cit = cdb.find(0);
            chain_println!(cit.get_value().unwrap().hash);

            // print table contents using find_primary from secondary index interface
            let s_idx = cdb.get_idx_by_hash();
            let (it, mut s_val) = s_idx.find_primary(0);

            if it.is_ok() {
                chain_println!(s_val);
            } else {
                chain_println!("not found!");
            }
        }

```

this prints:

```
dump: 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1e1f20
201f1e1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100
```

so clearly table data works fine when searching by simple primary index, but is printed with its 16 byte chunks reversed, as well as endianess swap internaly on each 16 byte chunk.

# Conclusion

Changes in this PR make the test suite run correctly as well as the zk proof submit test.